### PR TITLE
use List::Util instead of List::MoreUtils for any and none

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,7 +59,7 @@ WriteMakefile(
 		'File::Spec' => 3.4,
 		'Cwd' => 0,
 		'Socket' => 0,
-		'List::MoreUtils' => 0,
+		'List::Util' => 1.33,
 		'HTTP::BrowserDetect' => 3.10,	# Include bingbot
 		'File::Basename' => 0,
 		'String::Clean::XSS' => 0,

--- a/lib/CGI/Info.pm
+++ b/lib/CGI/Info.pm
@@ -13,7 +13,7 @@ use 5.008;
 use Log::Any qw($log);
 # use Cwd;
 # use JSON::Parse;
-use List::MoreUtils;	# Can go when expect goes
+use List::Util ();	# Can go when expect goes
 # use Sub::Private;
 use Sys::Path;
 
@@ -752,7 +752,7 @@ sub params {
 			}
 		}
 
-		if($self->{expect} && (List::MoreUtils::none { $_ eq $key } @{$self->{expect}})) {
+		if($self->{expect} && (List::Util::none { $_ eq $key } @{$self->{expect}})) {
 			next;
 		}
 		$value = _sanitise_input($value);
@@ -1434,7 +1434,7 @@ sub is_robot {
 			'http://www.seokicks.de/robot.html',
 		);
 		$referrer =~ s/\\/_/g;
-		if(($referrer =~ /\)/) || (List::MoreUtils::any { $_ =~ /^$referrer/ } @crawler_lists)) {
+		if(($referrer =~ /\)/) || (List::Util::any { $_ =~ /^$referrer/ } @crawler_lists)) {
 			$self->_debug("is_robot: blocked trawler $referrer");
 
 			if($self->{cache}) {


### PR DESCRIPTION
Suggestion: use `List::Util` for `any` and `none` instead of `List::MoreUtils`.  The former comes bundled with Perl, and as of version 1.33 includes `any` and `none`.